### PR TITLE
Fixed Dockerfile for allowing to build the application

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,5 @@
 FROM pytorch/pytorch:1.2-cuda10.0-cudnn7-devel
 RUN apt-get update && apt-get install -y sudo git wget tmux htop zip imagemagick
 RUN echo 'export PATH="/home/${USER}/.local/bin:${PATH}"' >> ~/.bashrc
+RUN pip install --upgrade pip setuptools wheel
 RUN pip install cython dill dominate imageio opencv-python pillow scipy==1.2.0 tensorflow==1.13.1 tqdm torchvision==0.4.0


### PR DESCRIPTION
A fix was needed to proceed with the current application's _Docker_ image build, as an error was shown when building the required wheels.
After the corresponding update of the required packages, the _Docker_ image build process is accomplished without any inconvenience.

This repository is such a great effort; thanks for sharing it.